### PR TITLE
single container invocation in action

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -12,27 +12,6 @@ RUN npx gulp
 
 FROM python:3.9
 
-ARG AUTHOR_EMAIL="obriencj@gmail.com"
-ARG GIT_REPO="https://github.com/obriencj/pelican-inelegant.git"
-ARG GIT_COMMIT=""
-ARG PROJECT_DESC="Inelegant themed Pelican site generator"
-ARG PROJECT_NAME="pelican-inelegant"
-ARG PROJECT_URL="https://github.com/obriencj/pelican-inelegant"
-
-LABEL \
-    net.preoccupied.image.git-repository="${GIT_REPO}" \
-    net.preoccupied.image.git-commit="${GIT_COMMIT}" \
-    org.label-schema.description="${PROJECT_DESC}" \
-    org.label-schema.name="${PROJECT_NAME}" \
-    org.label-schema.schema-version="1.0" \
-    org.label-schema.url="${PROJECT_URL}" \
-    org.label-schema.vcs-url="${PROJECT_URL}" \
-    org.opencontainers.image.authors="${AUTHOR_EMAIL}" \
-    org.opencontainers.image.description="${PROJECT_DESC}" \
-    org.opencontainers.image.title="${PROJECT_NAME}" \
-    org.opencontainers.image.url="${PROJECT_URL}"
-
-
 # Need this for the pelican-image-process plugin, or else our photos
 # will lose their EXIF orientation data
 RUN apt-get update ; apt-get install -y exiftool
@@ -43,6 +22,7 @@ WORKDIR /pelican
 COPY requirements.txt .
 
 # Install pelican and available plugins
+ENV PIP_ROOT_USER_ACTION=ignore
 RUN pip3 install --upgrade pip && pip3 install -r requirements.txt
 
 
@@ -65,7 +45,7 @@ RUN pelican-themes -i /pelican/inelegant
 
 # This script enables the github action to produce outputs reflecting
 # the settings used
-COPY dump-settings.py .
+COPY entrypoint.py .
 
 
 # since Pelican configurations are loaded as python modules, let's
@@ -75,8 +55,29 @@ ENV PYTHONDONTWRITEBYTECODE=1
 
 # launch this container with the site checkout mounted as /work
 WORKDIR /work
-ENTRYPOINT ["pelican"]
+ENTRYPOINT ["/pelican/entrypoint.py"]
 CMD []
+
+
+ARG AUTHOR_EMAIL="obriencj@gmail.com"
+ARG GIT_REPO="https://github.com/obriencj/pelican-inelegant.git"
+ARG GIT_COMMIT=""
+ARG PROJECT_DESC="Inelegant themed Pelican site generator"
+ARG PROJECT_NAME="pelican-inelegant"
+ARG PROJECT_URL="https://github.com/obriencj/pelican-inelegant"
+
+LABEL \
+    net.preoccupied.image.git-repository="${GIT_REPO}" \
+    net.preoccupied.image.git-commit="${GIT_COMMIT}" \
+    org.label-schema.description="${PROJECT_DESC}" \
+    org.label-schema.name="${PROJECT_NAME}" \
+    org.label-schema.schema-version="1.0" \
+    org.label-schema.url="${PROJECT_URL}" \
+    org.label-schema.vcs-url="${PROJECT_URL}" \
+    org.opencontainers.image.authors="${AUTHOR_EMAIL}" \
+    org.opencontainers.image.description="${PROJECT_DESC}" \
+    org.opencontainers.image.title="${PROJECT_NAME}" \
+    org.opencontainers.image.url="${PROJECT_URL}"
 
 
 # The end.

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,11 @@ description: "Build a static site using Pelican Inelegant"
 author: "Christopher O'Brien  <obriencj@gmail.com>"
 
 
+branding:
+  icon: 'layout'
+  color: 'orange'
+
+
 inputs:
   version:
     description: "pelican-inelegant container version"
@@ -60,37 +65,14 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Pull pelican-inelegant image
+    - name: Build site with pelican-inelegant
       shell: bash
       run: "\
-      podman pull ghcr.io/obriencj/pelican-inelegant\
-        '${{ inputs.version && format(':{0}', inputs.version) }}'"
-
-    - name: Tag pelican-inelegant image
-      shell: bash
-      run: "\
-      podman tag ghcr.io/obriencj/pelican-inelegant\
-        '${{ inputs.version && format(':{0}', inputs.version) }}'
-        pelican-inelegant"
-
-    - name: Record settings
-      id: settings
-      shell: bash
-      run: "\
-      podman run --rm --volume '${{ github.workspace }}':/work
-        --entrypoint /pelican/dump-settings.py
-        pelican-inelegant
-        ${{ inputs.settings && format('-s''{0}''', inputs.settings) }}
-        ${{ inputs.theme && format('-t''{0}''', inputs.theme) }}
-        ${{ inputs.output-path && format('-o''{0}''', inputs.output-path) }}
-        ${{ inputs.path && format('''{0}''', inputs.path) }}
-        >> $GITHUB_OUTPUT"
-
-    - name: Build site with pelican
-      shell: bash
-      run: "\
-      podman run --rm --volume '${{ github.workspace }}':/work
-        pelican-inelegant
+      podman run --rm
+        --volume '${{ github.workspace }}':/work
+        --volume \"$GITHUB_OUTPUT\":/pelican/github_output
+        ghcr.io/obriencj/pelican-inelegant\
+          '${{ inputs.version && format(':{0}', inputs.version) }}'
         ${{ inputs.settings && format('-s''{0}''', inputs.settings) }}
         ${{ inputs.theme && format('-t''{0}''', inputs.theme) }}
         ${{ inputs.output-path && format('-o''{0}''', inputs.output-path) }}

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -9,12 +9,24 @@ License: MIT
 """
 
 
-from pelican import DEFAULT_CONFIG_NAME, parse_arguments
+from pelican import DEFAULT_CONFIG_NAME, main, parse_arguments
 from pelican.settings import get_settings_from_file
 from shlex import quote
 
 
+# we're expecting this file to be provided as a volume mount when
+# invoked as an action. If it's not mounted, then we'll just create it
+# and it can be ignored.
+OUTPUT_VARS = "/pelican/github_output"
+
+
 def get_settings(argv):
+    """
+    Load settings in a manner similar to pelican, but without
+    expanding to absolute paths, and without erroring out if theme
+    isn't found. We just want to get the settings, not act on them.
+    """
+
     args = parse_arguments(argv)
     conf = args.settings
 
@@ -38,7 +50,13 @@ def get_settings(argv):
     return settings
 
 
-def main(argv):
+def entrypoint(argv):
+    """
+    Fetch and record the settings, then invoke pelican. This is
+    essentially just a thin wrapper to make sure we can get our
+    computed settings recorded for the github action output.
+    """
+
     settings = get_settings(argv)
 
     wanted = (
@@ -46,13 +64,17 @@ def main(argv):
         'THEME', 'SITEURL', 'SITENAME', 'SITESUBTITLE',
     )
 
-    for key in wanted:
-        print(f'{key}={quote(settings.get(key))}')
+    with open(OUTPUT_VARS, "at") as out:
+        for key in wanted:
+            print(f'{key}={quote(settings.get(key))}', file=out)
+
+    return main(argv) or 0
 
 
 if __name__ == '__main__':
     import sys
-    main(sys.argv[1:])
+    sys.argv[0] = "pelican"  # lie a little
+    sys.exit(entrypoint(sys.argv[1:]))
 
 
 # The end.


### PR DESCRIPTION
Update the container entrypoint to be a wrapper script that both records the settings and also invokes pelican. Update the action to mount the GITHUB_OUTPUT file for the entrypoint to use.