### PR TITLE
Upgrades

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -10,7 +10,7 @@ COPY source/ /build/source/
 RUN npx gulp
 
 
-FROM python:3.9
+FROM python:3.11
 
 # Need this for the pelican-image-process plugin, or else our photos
 # will lose their EXIF orientation data

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,21 +4,21 @@
 #
 #    pip-compile
 #
-asttokens==2.4.0
+anyio==4.0.0
+    # via watchfiles
+asttokens==2.4.1
     # via stack-data
 attrs==23.1.0
     # via
     #   jsonschema
     #   referencing
-backcall==0.2.0
-    # via ipython
 beautifulsoup4==4.12.2
     # via
     #   nbconvert
     #   pelican-image-process
 bleach==6.1.0
     # via nbconvert
-blinker==1.6.3
+blinker==1.7.0
     # via pelican
 decorator==5.1.1
     # via ipython
@@ -26,13 +26,15 @@ defusedxml==0.7.1
     # via nbconvert
 docutils==0.20.1
     # via pelican
-executing==2.0.0
+executing==2.0.1
     # via stack-data
-fastjsonschema==2.18.1
+fastjsonschema==2.19.0
     # via nbformat
 feedgenerator==2.1.0
     # via pelican
-ipython==8.16.1
+idna==3.4
+    # via anyio
+ipython==8.17.2
     # via pelican-liquid-tags
 jedi==0.19.1
     # via ipython
@@ -40,13 +42,13 @@ jinja2==3.1.2
     # via
     #   nbconvert
     #   pelican
-jsonschema==4.19.1
+jsonschema==4.19.2
     # via nbformat
-jsonschema-specifications==2023.7.1
+jsonschema-specifications==2023.11.1
     # via jsonschema
-jupyter-client==8.4.0
+jupyter-client==8.6.0
     # via nbclient
-jupyter-core==5.4.0
+jupyter-core==5.5.0
     # via
     #   jupyter-client
     #   nbclient
@@ -56,7 +58,7 @@ jupyterlab-pygments==0.2.2
     # via nbconvert
 lxml==4.9.3
     # via pelican-image-process
-markdown==3.5
+markdown==3.5.1
     # via
     #   pelican
     #   pelican-yaml-metadata
@@ -72,21 +74,23 @@ mdurl==0.1.2
     # via markdown-it-py
 mistune==3.0.2
     # via nbconvert
-nbclient==0.8.0
+nbclient==0.9.0
     # via nbconvert
-nbconvert==7.9.2
+nbconvert==7.11.0
     # via pelican-liquid-tags
 nbformat==5.9.2
     # via
     #   nbclient
     #   nbconvert
+ordered-set==4.1.0
+    # via pelican
 packaging==23.2
     # via nbconvert
 pandocfilters==1.5.0
     # via nbconvert
 parso==0.8.3
     # via jedi
-pelican[markdown]==4.8.0
+pelican[markdown]==4.9.1
     # via
     #   -r requirements.in
     #   pelican-image-process
@@ -100,13 +104,11 @@ pelican-yaml-metadata==2.1.2
     # via -r requirements.in
 pexpect==4.8.0
     # via ipython
-pickleshare==0.7.5
-    # via ipython
 pillow==10.1.0
     # via pelican-image-process
-platformdirs==3.11.0
+platformdirs==4.0.0
     # via jupyter-core
-prompt-toolkit==3.0.39
+prompt-toolkit==3.0.41
     # via ipython
 ptyprocess==0.7.0
     # via pexpect
@@ -124,20 +126,18 @@ python-dateutil==2.8.2
     #   jupyter-client
     #   pelican
 pytz==2023.3.post1
-    # via
-    #   feedgenerator
-    #   pelican
+    # via feedgenerator
 pyyaml==6.0.1
     # via pelican-yaml-metadata
 pyzmq==25.1.1
     # via jupyter-client
-referencing==0.30.2
+referencing==0.31.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-rich==13.6.0
+rich==13.7.0
     # via pelican
-rpds-py==0.10.6
+rpds-py==0.12.0
     # via
     #   jsonschema
     #   referencing
@@ -147,6 +147,8 @@ six==1.16.0
     #   bleach
     #   pelican-image-process
     #   python-dateutil
+sniffio==1.3.0
+    # via anyio
 soupsieve==2.5
     # via beautifulsoup4
 stack-data==0.6.3
@@ -155,7 +157,7 @@ tinycss2==1.2.1
     # via nbconvert
 tornado==6.3.3
     # via jupyter-client
-traitlets==5.11.2
+traitlets==5.13.0
     # via
     #   ipython
     #   jupyter-client
@@ -166,7 +168,9 @@ traitlets==5.11.2
     #   nbformat
 unidecode==1.3.7
     # via pelican
-wcwidth==0.2.8
+watchfiles==0.21.0
+    # via pelican
+wcwidth==0.2.10
     # via prompt-toolkit
 webencodings==0.5.1
     # via


### PR DESCRIPTION
updates to markdown 4.9.1 and base python image to 3.11, with all of the relevant dependencies as well.